### PR TITLE
Fixes the problem with intermediate NO_MAP lockups during operation

### DIFF
--- a/tasks/PathPlanner.cpp
+++ b/tasks/PathPlanner.cpp
@@ -144,7 +144,9 @@ void PathPlanner::updateHook()
     maps::grid::MLSMapSloped map;
     auto map_status = _map.readNewest(map, false);
 
-    if(map_status == RTT::NoData)
+    // The NO_MAP state should only be accessible if no map has ever been received.
+    // The planner should still be able to plan on 'old' maps (or least recently received map)
+    if((map_status == RTT::NoData) && !gotMap)
     {
         setIfNotSet(NO_MAP);
         return;


### PR DESCRIPTION
although a map is present to plan on